### PR TITLE
fix: do not use or expect v as the version prefix

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ fail() {
 }
 
 (
-  GOBIN="${ASDF_INSTALL_PATH}/bin" go install "golang.org/x/tools/cmd/goimports@${ASDF_INSTALL_VERSION}"
+  GOBIN="${ASDF_INSTALL_PATH}/bin" go install "golang.org/x/tools/cmd/goimports@v${ASDF_INSTALL_VERSION}"
   echo "The installation was successful!"
 ) || (
   rm -rf "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,4 +14,4 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd $releases_path" | grep '"ref":' | grep -v 'gopls/' | sed -e 's/.*\/\(v.*\)",/\1/' | sort_versions | xargs) 
+eval "$cmd $releases_path" | grep '"ref":' | grep -v 'gopls/' | sed -e 's/.*\/v\(.*\)",/\1/' | sort_versions | xargs


### PR DESCRIPTION
`asdf` doesn't use the `v` prefix for versions, or it's not really best practice (judging from other `asdf` plugins).

Commands like `asdf latest goimports` now work out of the box.
